### PR TITLE
Add support to RGB images

### DIFF
--- a/BoxBlur.py
+++ b/BoxBlur.py
@@ -1,0 +1,30 @@
+import numpy as np
+from PIL import Image
+from scipy.signal import convolve2d
+
+boxKernelDims = [3,5,7,9]
+
+def BoxBlur_random(img):
+    kernelidx = np.random.randint(0, len(boxKernelDims))    
+    kerneldim = boxKernelDims[kernelidx]
+    return BoxBlur(img, kerneldim)
+
+def BoxBlur(img, dim):
+    imgarray = np.array(img, dtype="float32")
+    kernel = BoxKernel(dim)
+    if imgarray.ndim==3 and imgarray.shape[-1]==3:
+        convolved = np.stack([convolve2d(imgarray[...,channel_id], 
+                    kernel, mode='same', 
+                    fillvalue=255.0).astype("uint8") 
+                    for channel_id in range(3)], axis=2)
+    else:
+        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
+    img = Image.fromarray(convolved)
+    return img
+
+def BoxKernel(dim):
+    kernelwidth = dim
+    kernel = np.ones((kernelwidth, kernelwidth), dtype=np.float32)        
+    normalizationFactor = np.count_nonzero(kernel)
+    kernel = kernel / normalizationFactor
+    return kernel

--- a/DefocusBlur.py
+++ b/DefocusBlur.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+from PIL import Image
+from scipy.signal import convolve2d
+from skimage.draw import circle
+
+defocusKernelDims = [3,5,7,9]
+
+def DefocusBlur_random(img):
+    kernelidx = np.random.randint(0, len(defocusKernelDims))    
+    kerneldim = defocusKernelDims[kernelidx]
+    return DefocusBlur(img, kerneldim)
+
+def DefocusBlur(img, dim):
+    imgarray = np.array(img, dtype="float32")
+    kernel = DiskKernel(dim)
+    if imgarray.ndim==3 and imgarray.shape[-1]==3:
+        convolved = np.stack([convolve2d(imgarray[...,channel_id], 
+                    kernel, mode='same', 
+                    fillvalue=255.0).astype("uint8") 
+                    for channel_id in range(3)], axis=2)
+    else:
+        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
+    img = Image.fromarray(convolved)
+    return img
+
+
+def DiskKernel(dim):
+    kernelwidth = dim
+    kernel = np.zeros((kernelwidth, kernelwidth), dtype=np.float32)
+    circleCenterCoord = dim / 2
+    circleRadius = circleCenterCoord +1
+    
+    rr, cc = circle(circleCenterCoord, circleCenterCoord, circleRadius)
+    kernel[rr,cc]=1
+    
+    if(dim == 3 or dim == 5):
+        kernel = Adjust(kernel, dim)
+        
+    normalizationFactor = np.count_nonzero(kernel)
+    kernel = kernel / normalizationFactor
+    return kernel
+
+def Adjust(kernel, kernelwidth):
+    kernel[0,0] = 0
+    kernel[0,kernelwidth-1]=0
+    kernel[kernelwidth-1,0]=0
+    kernel[kernelwidth-1, kernelwidth-1] =0 
+    return kernel

--- a/LinearMotionBlur.py
+++ b/LinearMotionBlur.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+import math
+import numpy as np
+from PIL import Image
+from scipy.signal import convolve2d
+from skimage.draw import line
+
+from LineDictionary import LineDictionary
+
+lineLengths =[3,5,7,9]
+lineTypes = ["full", "right", "left"]
+
+lineDict = LineDictionary()
+
+def LinearMotionBlur_random(img):
+    lineLengthIdx = np.random.randint(0, len(lineLengths))
+    lineTypeIdx = np.random.randint(0, len(lineTypes)) 
+    lineLength = lineLengths[lineLengthIdx]
+    lineType = lineTypes[lineTypeIdx]
+    lineAngle = randomAngle(lineLength)
+    return LinearMotionBlur(img, lineLength, lineAngle, lineType)
+
+def LinearMotionBlur(img, dim, angle, linetype):
+    imgarray = np.array(img, dtype="float32")
+    kernel = LineKernel(dim, angle, linetype)
+    if imgarray.ndim==3 and imgarray.shape[-1]==3:
+        convolved = np.stack([convolve2d(imgarray[...,channel_id], 
+                    kernel, mode='same', 
+                    fillvalue=255.0).astype("uint8") 
+                    for channel_id in range(3)], axis=2)
+    else:
+        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
+    img = Image.fromarray(convolved)
+    return img
+
+def LineKernel(dim, angle, linetype):
+    kernelwidth = dim
+    kernelCenter = int(math.floor(dim/2))
+    angle = SanitizeAngleValue(kernelCenter, angle)
+    kernel = np.zeros((kernelwidth, kernelwidth), dtype=np.float32)
+    lineAnchors = lineDict.lines[dim][angle]
+    if(linetype == 'right'):
+        lineAnchors[0] = kernelCenter
+        lineAnchors[1] = kernelCenter
+    if(linetype == 'left'):
+        lineAnchors[2] = kernelCenter
+        lineAnchors[3] = kernelCenter
+    rr,cc = line(lineAnchors[0], lineAnchors[1], lineAnchors[2], lineAnchors[3])
+    kernel[rr,cc]=1
+    normalizationFactor = np.count_nonzero(kernel)
+    kernel = kernel / normalizationFactor        
+    return kernel
+
+def SanitizeAngleValue(kernelCenter, angle):
+    numDistinctLines = kernelCenter * 4
+    angle = math.fmod(angle, 180.0)
+    validLineAngles = np.linspace(0,180, numDistinctLines, endpoint = False)
+    angle = nearestValue(angle, validLineAngles)
+    return angle
+
+def nearestValue(theta, validAngles):
+    idx = (np.abs(validAngles-theta)).argmin()
+    return validAngles[idx]
+
+def randomAngle(kerneldim):
+    kernelCenter = int(math.floor(kerneldim/2))
+    numDistinctLines = kernelCenter * 4
+    validLineAngles = np.linspace(0,180, numDistinctLines, endpoint = False)
+    angleIdx = np.random.randint(0, len(validLineAngles))
+    return int(validLineAngles[angleIdx])

--- a/PsfBlur.py
+++ b/PsfBlur.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import numpy as np
+import pickle
+from PIL import Image
+from scipy.signal import convolve2d
+import os.path
+
+pickledPsfFilename =os.path.join(os.path.dirname( __file__),"psf.pkl")
+
+with open(pickledPsfFilename, 'rb') as pklfile:
+    psfDictionary = pickle.load(pklfile)
+
+
+def PsfBlur(img, psfid):
+    imgarray = np.array(img, dtype="float32")
+    kernel = psfDictionary[psfid]
+    if imgarray.ndim==3 and imgarray.shape[-1]==3:
+        convolved = np.stack([convolve2d(imgarray[...,channel_id], 
+                    kernel, mode='same', 
+                    fillvalue=255.0).astype("uint8") 
+                    for channel_id in range(3)], axis=2)
+    else:
+        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
+    img = Image.fromarray(convolved)
+    return img
+    
+def PsfBlur_random(img):
+    psfid = np.random.randint(0, len(psfDictionary))
+    return PsfBlur(img, psfid)
+    
+    

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 #Pyblur
 ##Python image blurring routines.
+#This is tested on python2.7
+#You can run blurred_image_generator.py as a quick start
 Pyblur is a collection of simple image blurring routines.<br>
 It supports Gaussian, Disk, Box, and Linear Motion Blur Kernels as well as the Point Spread Functions
 used in [Convolutional Neural Networks for Direct Text Deblurring](http://www.fit.vutbr.cz/~ihradis/CNN-Deblur/).<br>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 #Pyblur
 ##Python image blurring routines.
-#This is tested on python2.7
-#You can run blurred_image_generator.py as a quick start
+
+This is tested on python2.7
+
+You can run blurred_image_generator.py as a quick start
+
 Pyblur is a collection of simple image blurring routines.<br>
 It supports Gaussian, Disk, Box, and Linear Motion Blur Kernels as well as the Point Spread Functions
 used in [Convolutional Neural Networks for Direct Text Deblurring](http://www.fit.vutbr.cz/~ihradis/CNN-Deblur/).<br>

--- a/blurred_image_generator.py
+++ b/blurred_image_generator.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Mon Dec 18 08:27:25 2017
+
+@author: user
+"""
+
+import os
+from PIL import Image
+from pyblur import GaussianBlur_random, DefocusBlur_random
+from pyblur import BoxBlur_random, LinearMotionBlur_random
+from pyblur import PsfBlur_random
+from tqdm import tqdm
+from itertools import product
+import argparse
+
+def append_tag(name, tag):
+    tokens = name.rsplit('.', 1)
+    #tokens[0]: xxx, tokens[1]: jpg/jpeg
+    return '.'.join([tokens[0]+'_'+tag, tokens[1]])
+
+def save_img(img, fname):
+    with open(fname, 'wb') as f:
+        img.save(f)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--imagedir", type=str, 
+                    help="the folder of your images",
+                    default="images")
+parser.add_argument("--blurreddir", type=str, 
+                    help="the folder of generated blurred images",
+                    default="blurred")
+parser.add_argument("--blurred_num", type=int,
+                    help="the number of blurred images to be generated " + 
+                    "per type per image",
+                    default=5)
+
+args = parser.parse_args()
+imagedir = args.imagedir
+blurreddir = args.blurreddir
+blurred_num = args.blurred_num
+
+if not os.path.isdir(blurreddir):
+    os.makedirs(blurreddir)
+    
+for fimg, count in tqdm(product(os.listdir(imagedir), range(blurred_num))):
+    img = Image.open("{}/{}".format(imagedir, fimg))
+    
+    blurred = GaussianBlur_random(img)
+    save_img(blurred, "{}/{}".format(blurreddir, 
+             append_tag(fimg, "GaussianBlur_{}".format(count))))
+    
+    blurred = DefocusBlur_random(img)
+    save_img(blurred, "{}/{}".format(blurreddir, 
+             append_tag(fimg, "DefocusBlur_{}".format(count))))
+    
+    blurred = BoxBlur_random(img)
+    save_img(blurred, "{}/{}".format(blurreddir, 
+             append_tag(fimg, "BoxBlur_{}".format(count))))
+
+    blurred = LinearMotionBlur_random(img)
+    save_img(blurred, "{}/{}".format(blurreddir, 
+             append_tag(fimg, "LinearMotionBlur_{}".format(count))))
+    
+    blurred = PsfBlur_random(img)
+    save_img(blurred, "{}/{}".format(blurreddir, 
+             append_tag(fimg, "PsfBlur_{}".format(count))))
+    
+    img.close()


### PR DESCRIPTION
reference to this issue: https://github.com/lospooky/pyblur/issues/2
make some changes in BoxBlur.py, DefocusBlur.py, LinearMotionBlur.py, PsfBlur.py, so that they can accept RGB images.
Add blurred_image_generator.py as the sample usage.