### PR TITLE
Add pluggable backend system (numpy, scipy, opencv)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) — [Semantic V
 
 ---
 
+## [1.3.0] — 28-03-2026
+
+### Added
+- All public blur functions (`box_blur`, `defocus_blur`, `gaussian_blur`, `linear_motion_blur`, `psf_blur`, and their `_random` / `randomized_blur` variants) now accept a `backend=` keyword argument. Accepts `"scipy"`, `"numpy"`, `"opencv"`, or a custom `Backend` protocol instance.
+- Pure-numpy backend (`"numpy"`): always available, no optional dependencies. Automatically becomes the default when scipy is not installed.
+- OpenCV backend (`"opencv"`): opt-in via `backend="opencv"`; requires `pip install pyblur[opencv]`.
+
+### Changed
+- `scipy` and `scikit-image` are no longer required dependencies. The core package (`numpy`, `pillow`) now works standalone. Install `pyblur[scipy]` to restore the scipy-backed default explicitly.
+- Default backend remains `"scipy"` when scipy is installed — no behaviour change for existing users.
+
+---
+
 ## [1.2.0] — 22-03-2026
 
 ### Changed
@@ -50,6 +63,7 @@ Full modernization of a Python 2-era codebase. Requires Python ≥ 3.10.
 
 Initial public release. Python 2.7 only.
 
+[1.3.0]: https://github.com/lospooky/pyblur/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/lospooky/pyblur/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/lospooky/pyblur/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/lospooky/pyblur/compare/v0.2.3...v1.0.0

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ PSF kernels are taken from [Convolutional Neural Networks for Direct Text Deblur
 pip install pyblur
 ```
 
-**Requirements:** Python ≥ 3.10, numpy, pillow, scikit-image, scipy.
+**Requirements:** Python ≥ 3.10, numpy, pillow.
+
+Optional backends ship as extras:
+
+```bash
+pip install pyblur[scipy]    # scipy + scikit-image (default backend when installed)
+pip install pyblur[opencv]   # opencv-python
+```
 
 ---
 
@@ -36,6 +43,33 @@ blurred = pyblur.gaussian_blur(img, bandwidth=1.5)
 
 # Or let pyblur choose everything at random
 blurred = pyblur.randomized_blur(img)
+
+# Explicitly choose a backend
+blurred = pyblur.box_blur(img, dim=5, backend="opencv")
+```
+
+---
+
+## Backends
+
+Every public function accepts an optional `backend=` keyword argument that controls which convolution engine is used.
+
+| Backend | Extra | Notes |
+|---------|-------|-------|
+| `"scipy"` | `pyblur[scipy]` | Default when scipy is installed. Identical output to v1.2 and earlier. |
+| `"numpy"` | _(none)_ | Always available. Default when scipy is not installed. |
+| `"opencv"` | `pyblur[opencv]` | Opt-in only; never set as the automatic default. |
+
+The default is selected automatically at import time: `"scipy"` if scipy is importable, `"numpy"` otherwise. Passing a backend name overrides this for that call only.
+
+```python
+# Override per-call
+blurred = pyblur.defocus_blur(img, dim=7, backend="numpy")
+blurred = pyblur.linear_motion_blur(img, dim=5, angle=30.0, linetype="full", backend="opencv")
+
+# Or pass a Backend instance directly
+from pyblur._backends._numpy import PilNumpyBackend
+blurred = pyblur.gaussian_blur(img, bandwidth=2.0, backend=PilNumpyBackend())
 ```
 
 ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ requires-python = ">=3.10"
 dependencies = [
     "numpy>=1.21",
     "pillow>=9.0",
-    "scikit-image>=0.20",
-    "scipy>=1.7",
 ]
 
 classifiers = [
@@ -32,6 +30,11 @@ classifiers = [
     "Topic :: Multimedia :: Graphics",
     "Topic :: Scientific/Engineering :: Image Processing",
 ]
+
+[project.optional-dependencies]
+scipy = [
+    "scikit-image>=0.20",
+    "scipy>=1.7",
 
 [project.urls]
 Homepage = "https://github.com/lospooky/pyblur"
@@ -75,6 +78,8 @@ select = ["E", "F", "W", "I"]
 
 [dependency-groups]
 dev = [
+    "scikit-image>=0.20",
+    "scipy>=1.7",
     "ty",
     "pytest>=8.4.2",
     "pytest-cov>=7.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,10 @@ classifiers = [
 scipy = [
     "scikit-image>=0.20",
     "scipy>=1.7",
+]
+opencv = [
+    "opencv-python>=4.5",
+]
 
 [project.urls]
 Homepage = "https://github.com/lospooky/pyblur"
@@ -78,6 +82,7 @@ select = ["E", "F", "W", "I"]
 
 [dependency-groups]
 dev = [
+    "opencv-python>=4.5",
     "scikit-image>=0.20",
     "scipy>=1.7",
     "ty",

--- a/src/pyblur/__init__.py
+++ b/src/pyblur/__init__.py
@@ -1,3 +1,4 @@
+from pyblur._backends import Backend, get_backend, register, set_default
 from pyblur.box_blur import box_blur, box_blur_random
 from pyblur.defocus_blur import defocus_blur, defocus_blur_random
 from pyblur.gaussian_blur import gaussian_blur, gaussian_blur_random
@@ -6,15 +7,19 @@ from pyblur.psf_blur import psf_blur, psf_blur_random
 from pyblur.randomized_blur import randomized_blur
 
 __all__ = [
+    "Backend",
     "box_blur",
     "box_blur_random",
     "defocus_blur",
     "defocus_blur_random",
     "gaussian_blur",
     "gaussian_blur_random",
+    "get_backend",
     "linear_motion_blur",
     "linear_motion_blur_random",
     "psf_blur",
     "psf_blur_random",
     "randomized_blur",
+    "register",
+    "set_default",
 ]

--- a/src/pyblur/_backends/__init__.py
+++ b/src/pyblur/_backends/__init__.py
@@ -92,8 +92,36 @@ def get_backend(backend: "str | Backend | None" = None) -> Backend:
 # ---------------------------------------------------------------------------
 # Register built-in backends and set the default at import time.
 # ---------------------------------------------------------------------------
-from pyblur._backends._pil_scipy import PilScipyBackend as _PilScipyBackend  # noqa: E402
 
-_scipy_backend = _PilScipyBackend()
-register(_scipy_backend)
-set_default("scipy")
+
+def _init_backends() -> None:
+    """Register built-in backends; called once at module import.
+
+    * ``"numpy"`` is always registered and set as baseline default.
+    * ``"scipy"`` is registered and becomes the default when scipy is importable
+      (identical behaviour to v1.2).  Falls back to ``"numpy"`` otherwise.
+    * ``"opencv"`` is registered when opencv-python is importable; it is never
+      made the automatic default (must be opted-in via ``backend="opencv"``).
+    """
+    from pyblur._backends._numpy import PilNumpyBackend as _PilNumpyBackend
+
+    register(_PilNumpyBackend())
+    set_default("numpy")  # baseline; upgraded to scipy below if available
+
+    try:
+        from pyblur._backends._pil_scipy import PilScipyBackend as _PilScipyBackend
+
+        register(_PilScipyBackend())
+        set_default("scipy")
+    except ImportError:
+        pass  # scipy unavailable; numpy remains the default
+
+    try:
+        from pyblur._backends._opencv import PilOpenCVBackend as _PilOpenCVBackend
+
+        register(_PilOpenCVBackend())
+    except ImportError:
+        pass  # opencv unavailable; no-op
+
+
+_init_backends()

--- a/src/pyblur/_backends/__init__.py
+++ b/src/pyblur/_backends/__init__.py
@@ -1,0 +1,99 @@
+"""Backend registry and protocol for pyblur convolution backends."""
+from typing import Protocol, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+
+@runtime_checkable
+class Backend(Protocol):  # pragma: no cover
+    """Protocol all pyblur backends must satisfy.
+
+    A backend is responsible for applying a convolution kernel or a named
+    blur (e.g. Gaussian) to a PIL image.  The default implementation is
+    :class:`~pyblur._backends._pil_scipy.PilScipyBackend`.
+    """
+
+    name: str
+
+    def apply_kernel(
+        self, img: Image.Image, kernel: NDArray[np.float32]
+    ) -> Image.Image:
+        """Convolve *img* with *kernel*; return the same image type."""
+        ...
+
+    def gaussian_blur(self, img: Image.Image, sigma: float) -> Image.Image:
+        """Apply a Gaussian blur with *sigma*; may use a native fast path."""
+        ...
+
+
+_registry: dict[str, Backend] = {}
+_default: Backend | None = None
+
+
+def register(backend: Backend) -> None:
+    """Register *backend* under its :attr:`~Backend.name`."""
+    _registry[backend.name] = backend
+
+
+def set_default(name: str) -> None:
+    """Set the default backend used when ``backend=None`` is passed.
+
+    Parameters
+    ----------
+    name : str
+        Must be the :attr:`~Backend.name` of a previously registered backend.
+
+    Raises
+    ------
+    ValueError
+        If *name* is not in the registry.
+    """
+    global _default
+    if name not in _registry:
+        raise ValueError(
+            f"Unknown backend {name!r}. Available: {sorted(_registry)}"
+        )
+    _default = _registry[name]
+
+
+def get_backend(backend: "str | Backend | None" = None) -> Backend:
+    """Resolve *backend* to a concrete :class:`Backend` instance.
+
+    Parameters
+    ----------
+    backend : str | Backend | None
+        * ``None`` — return the registered default.
+        * ``str`` — look up by name in the registry.
+        * :class:`Backend` instance — return unchanged.
+
+    Raises
+    ------
+    ValueError
+        If a string name is not found in the registry.
+    RuntimeError
+        If ``None`` is passed and no default has been set (should never
+        happen after normal import, which registers the scipy backend).
+    """
+    if backend is None:
+        if _default is None:  # pragma: no cover
+            raise RuntimeError("No backend registered.")
+        return _default
+    if isinstance(backend, str):
+        if backend not in _registry:
+            raise ValueError(
+                f"Unknown backend {backend!r}. Available: {sorted(_registry)}"
+            )
+        return _registry[backend]
+    return backend  # Backend instance passed directly
+
+
+# ---------------------------------------------------------------------------
+# Register built-in backends and set the default at import time.
+# ---------------------------------------------------------------------------
+from pyblur._backends._pil_scipy import PilScipyBackend as _PilScipyBackend  # noqa: E402
+
+_scipy_backend = _PilScipyBackend()
+register(_scipy_backend)
+set_default("scipy")

--- a/src/pyblur/_backends/_numpy.py
+++ b/src/pyblur/_backends/_numpy.py
@@ -1,0 +1,60 @@
+"""Pure numpy convolution backend (no scipy or scikit-image required)."""
+import math
+
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+
+def _convolve2d(
+    channel: NDArray[np.float32], kernel: NDArray[np.float32]
+) -> NDArray[np.uint8]:
+    """Convolve a 2-D float32 channel with *kernel* (same-size output, fill=255)."""
+    kh, kw = kernel.shape
+    pad_h, pad_w = kh // 2, kw // 2
+    padded = np.pad(
+        channel,
+        ((pad_h, pad_h), (pad_w, pad_w)),
+        mode="constant",
+        constant_values=255.0,
+    )
+    windows = np.lib.stride_tricks.sliding_window_view(padded, (kh, kw))
+    result = (windows * kernel).sum(axis=(-2, -1))
+    return result.clip(0, 255).astype("uint8")
+
+
+def _gaussian_kernel2d(sigma: float) -> NDArray[np.float32]:
+    """Build a 2-D Gaussian kernel for the given *sigma*."""
+    radius = max(1, math.ceil(3.0 * sigma))
+    x = np.arange(-radius, radius + 1, dtype=np.float32)
+    k1d = np.exp(-0.5 * (x / sigma) ** 2)
+    k2d = np.outer(k1d, k1d).astype(np.float32)
+    k2d /= k2d.sum()
+    return k2d
+
+
+class PilNumpyBackend:
+    """Backend that uses PIL for I/O and pure numpy for convolution."""
+
+    name = "numpy"
+
+    def apply_kernel(
+        self, img: Image.Image, kernel: NDArray[np.float32]
+    ) -> Image.Image:
+        """Convolve *img* with *kernel* and return the result as a PIL image."""
+        imgarray = np.array(img, dtype="float32")
+        if imgarray.ndim == 3:
+            convolved = np.stack(
+                [
+                    _convolve2d(imgarray[..., c], kernel)
+                    for c in range(imgarray.shape[2])
+                ],
+                axis=2,
+            )
+        else:
+            convolved = _convolve2d(imgarray, kernel)
+        return Image.fromarray(convolved)
+
+    def gaussian_blur(self, img: Image.Image, sigma: float) -> Image.Image:
+        """Apply a Gaussian blur by building a kernel and convolving."""
+        return self.apply_kernel(img, _gaussian_kernel2d(sigma))

--- a/src/pyblur/_backends/_opencv.py
+++ b/src/pyblur/_backends/_opencv.py
@@ -1,0 +1,41 @@
+"""OpenCV convolution backend (optional; requires opencv-python)."""
+
+import cv2
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image
+
+
+class PilOpenCVBackend:
+    """Backend that uses PIL for I/O and OpenCV for convolution and Gaussian blur."""
+
+    name = "opencv"
+
+    def apply_kernel(
+        self, img: Image.Image, kernel: NDArray[np.float32]
+    ) -> Image.Image:
+        """Convolve *img* with *kernel* using cv2.filter2D.
+
+        Borders are padded with 255 to match the scipy/numpy backend behaviour.
+        """
+        imgarray = np.array(img, dtype=np.float32)
+        kh, kw = kernel.shape
+        pad_h, pad_w = kh // 2, kw // 2
+        padding = (
+            ((pad_h, pad_h), (pad_w, pad_w), (0, 0))
+            if imgarray.ndim == 3
+            else ((pad_h, pad_h), (pad_w, pad_w))
+        )
+        padded = np.pad(imgarray, padding, mode="constant", constant_values=255.0)
+        result = cv2.filter2D(
+            padded, ddepth=cv2.CV_32F, kernel=kernel, borderType=cv2.BORDER_ISOLATED
+        )
+        h, w = imgarray.shape[:2]
+        cropped = result[pad_h : pad_h + h, pad_w : pad_w + w]
+        return Image.fromarray(cropped.clip(0, 255).astype(np.uint8))
+
+    def gaussian_blur(self, img: Image.Image, sigma: float) -> Image.Image:
+        """Apply a Gaussian blur using cv2.GaussianBlur."""
+        imgarray = np.array(img)
+        result = cv2.GaussianBlur(imgarray, (0, 0), sigma)
+        return Image.fromarray(result)

--- a/src/pyblur/_backends/_pil_scipy.py
+++ b/src/pyblur/_backends/_pil_scipy.py
@@ -1,0 +1,36 @@
+"""PIL + scipy convolution backend (default)."""
+import numpy as np
+from numpy.typing import NDArray
+from PIL import Image, ImageFilter
+from scipy.signal import convolve2d
+
+
+class PilScipyBackend:
+    """Backend that uses PIL for I/O and scipy for convolution."""
+
+    name = "scipy"
+
+    def apply_kernel(
+        self, img: Image.Image, kernel: NDArray[np.float32]
+    ) -> Image.Image:
+        """Convolve *img* with *kernel* and return the result as a PIL image."""
+        imgarray = np.array(img, dtype="float32")
+        if imgarray.ndim == 3:
+            convolved = np.stack(
+                [
+                    convolve2d(
+                        imgarray[..., c], kernel, mode="same", fillvalue=255.0
+                    ).astype("uint8")
+                    for c in range(imgarray.shape[2])
+                ],
+                axis=2,
+            )
+        else:
+            convolved = convolve2d(
+                imgarray, kernel, mode="same", fillvalue=255.0
+            ).astype("uint8")
+        return Image.fromarray(convolved)
+
+    def gaussian_blur(self, img: Image.Image, sigma: float) -> Image.Image:
+        """Apply a Gaussian blur using PIL's built-in fast path."""
+        return img.filter(ImageFilter.GaussianBlur(sigma))

--- a/src/pyblur/_kernels.py
+++ b/src/pyblur/_kernels.py
@@ -10,8 +10,6 @@ from typing import Literal
 import numpy as np
 from numpy.lib.npyio import NpzFile
 from numpy.typing import NDArray
-from skimage.draw import disk as skimage_disk
-from skimage.draw import line as skimage_line
 
 # ---------------------------------------------------------------------------
 # PSF data (loaded lazily from the bundled psf.npz)
@@ -53,8 +51,9 @@ def disk_kernel(dim: int) -> NDArray[np.float32]:
     """Return a normalised *dim*×*dim* circular disk (defocus) kernel."""
     kernel = np.zeros((dim, dim), dtype=np.float32)
     center = dim // 2
-    rr, cc = skimage_disk((center, center), center + 1, shape=kernel.shape)
-    kernel[rr, cc] = 1
+    y, x = np.ogrid[:dim, :dim]
+    mask = (y - center) ** 2 + (x - center) ** 2 < (center + 1) ** 2
+    kernel[mask] = 1
     if dim == 3 or dim == 5:
         kernel = _disk_adjust(kernel, dim)
     kernel /= np.count_nonzero(kernel)
@@ -82,6 +81,30 @@ def line_endpoints(dim: int, angle: float) -> tuple[int, int, int, int]:
     return r0, c0, r1, c1
 
 
+def _bresenham_line(
+    r0: int, c0: int, r1: int, c1: int
+) -> tuple[NDArray[np.intp], NDArray[np.intp]]:
+    """Return row/col index arrays for a Bresenham line from (r0,c0) to (r1,c1)."""
+    dr = abs(r1 - r0)
+    dc = abs(c1 - c0)
+    sr = 1 if r0 < r1 else -1
+    sc = 1 if c0 < c1 else -1
+    err = dr - dc
+    rows: list[int] = [r0]
+    cols: list[int] = [c0]
+    while r0 != r1 or c0 != c1:
+        e2 = 2 * err
+        if e2 > -dc:
+            err -= dc
+            r0 += sr
+        if e2 < dr:
+            err += dr
+            c0 += sc
+        rows.append(r0)
+        cols.append(c0)
+    return np.array(rows, dtype=np.intp), np.array(cols, dtype=np.intp)
+
+
 def line_kernel(
     dim: int, angle: float, linetype: Literal["full", "right", "left"]
 ) -> NDArray[np.float32]:
@@ -92,7 +115,7 @@ def line_kernel(
         r0, c0 = kernel_center, kernel_center
     elif linetype == "left":
         r1, c1 = kernel_center, kernel_center
-    rr, cc = skimage_line(r0, c0, r1, c1)
+    rr, cc = _bresenham_line(r0, c0, r1, c1)
     kernel = np.zeros((dim, dim), dtype=np.float32)
     kernel[rr, cc] = 1
     kernel /= np.count_nonzero(kernel)

--- a/src/pyblur/_kernels.py
+++ b/src/pyblur/_kernels.py
@@ -1,0 +1,104 @@
+"""Pure kernel factories — no I/O, no PIL, no backend dependencies.
+
+All functions return a normalised float32 ndarray suitable for convolution.
+"""
+
+import math
+import os.path
+from typing import Literal
+
+import numpy as np
+from numpy.lib.npyio import NpzFile
+from numpy.typing import NDArray
+from skimage.draw import disk as skimage_disk
+from skimage.draw import line as skimage_line
+
+# ---------------------------------------------------------------------------
+# PSF data (loaded lazily from the bundled psf.npz)
+# ---------------------------------------------------------------------------
+
+_psf_data: NpzFile | None = None
+
+
+def _load_psf() -> NpzFile:
+    global _psf_data
+    if _psf_data is None:
+        npz_path = os.path.join(os.path.dirname(__file__), "psf.npz")
+        _psf_data = np.load(npz_path, allow_pickle=False)
+    return _psf_data
+
+
+# ---------------------------------------------------------------------------
+# Kernel factories
+# ---------------------------------------------------------------------------
+
+
+def box_kernel(dim: int) -> NDArray[np.float32]:
+    """Return a normalised *dim*×*dim* box (mean) kernel."""
+    kernel = np.ones((dim, dim), dtype=np.float32)
+    kernel /= np.count_nonzero(kernel)
+    return kernel
+
+
+def _disk_adjust(kernel: NDArray[np.float32], kernelwidth: int) -> NDArray[np.float32]:
+    """Zero the four corners of a disk kernel (used for dim 3 and 5)."""
+    kernel[0, 0] = 0
+    kernel[0, kernelwidth - 1] = 0
+    kernel[kernelwidth - 1, 0] = 0
+    kernel[kernelwidth - 1, kernelwidth - 1] = 0
+    return kernel
+
+
+def disk_kernel(dim: int) -> NDArray[np.float32]:
+    """Return a normalised *dim*×*dim* circular disk (defocus) kernel."""
+    kernel = np.zeros((dim, dim), dtype=np.float32)
+    center = dim // 2
+    rr, cc = skimage_disk((center, center), center + 1, shape=kernel.shape)
+    kernel[rr, cc] = 1
+    if dim == 3 or dim == 5:
+        kernel = _disk_adjust(kernel, dim)
+    kernel /= np.count_nonzero(kernel)
+    return kernel
+
+
+def line_endpoints(dim: int, angle: float) -> tuple[int, int, int, int]:
+    """Compute boundary-crossing line endpoints for a *dim*×*dim* kernel at *angle* degrees.
+
+    Angles outside ``[0°, 180°)`` are wrapped modulo 180°.  Returns
+    ``(r0, c0, r1, c1)`` clamped to ``[0, dim-1]``.
+    """
+    c = dim // 2
+    rad = math.radians(math.fmod(angle, 180.0))
+    dr = -math.sin(rad)  # row delta (row 0 is top, so sin is negated)
+    dc = math.cos(rad)   # col delta
+    t_row = c / abs(dr) if abs(dr) > 1e-9 else float("inf")
+    t_col = c / abs(dc) if abs(dc) > 1e-9 else float("inf")
+    t = min(t_row, t_col)
+    edge = dim - 1
+    r0 = max(0, min(edge, int(round(c - t * dr))))
+    c0 = max(0, min(edge, int(round(c - t * dc))))
+    r1 = max(0, min(edge, int(round(c + t * dr))))
+    c1 = max(0, min(edge, int(round(c + t * dc))))
+    return r0, c0, r1, c1
+
+
+def line_kernel(
+    dim: int, angle: float, linetype: Literal["full", "right", "left"]
+) -> NDArray[np.float32]:
+    """Return a normalised *dim*×*dim* motion-line kernel."""
+    kernel_center = dim // 2
+    r0, c0, r1, c1 = line_endpoints(dim, angle)
+    if linetype == "right":
+        r0, c0 = kernel_center, kernel_center
+    elif linetype == "left":
+        r1, c1 = kernel_center, kernel_center
+    rr, cc = skimage_line(r0, c0, r1, c1)
+    kernel = np.zeros((dim, dim), dtype=np.float32)
+    kernel[rr, cc] = 1
+    kernel /= np.count_nonzero(kernel)
+    return kernel
+
+
+def psf_kernel(psfid: int) -> NDArray[np.float32]:
+    """Return the pre-computed PSF kernel for the given *psfid*."""
+    return _load_psf()[str(psfid)]

--- a/src/pyblur/box_blur.py
+++ b/src/pyblur/box_blur.py
@@ -1,7 +1,7 @@
 import numpy as np
 from PIL import Image
-from scipy.signal import convolve2d
 
+from pyblur._backends import Backend, get_backend
 from pyblur._kernels import box_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
@@ -12,23 +12,13 @@ from pyblur._validation import (
 )
 
 
-def _box_blur_impl(img: Image.Image, dim: int) -> Image.Image:
-    imgarray = np.array(img, dtype="float32")
-    kernel = box_kernel(dim)
-    if imgarray.ndim == 3:
-        convolved = np.stack(
-            [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
-             for c in range(imgarray.shape[2])],
-            axis=2,
-        )
-    else:
-        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
-    return Image.fromarray(convolved)
+def _box_blur_impl(img: Image.Image, dim: int, backend: Backend) -> Image.Image:
+    return backend.apply_kernel(img, box_kernel(dim))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
-def box_blur_random(img: Image.Image) -> Image.Image:
+def box_blur_random(img: Image.Image, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a box blur with a randomly chosen kernel size.
 
     Parameters
@@ -42,13 +32,13 @@ def box_blur_random(img: Image.Image) -> Image.Image:
         Blurred image with the same dimensions as the input.
     """
     kerneldim = _KERNEL_DIMS[np.random.randint(0, len(_KERNEL_DIMS))]
-    return _box_blur_impl(img, kerneldim)
+    return _box_blur_impl(img, kerneldim, get_backend(backend))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
 @validate_dim(_KERNEL_DIMS)
-def box_blur(img: Image.Image, dim: int) -> Image.Image:
+def box_blur(img: Image.Image, dim: int, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a box (mean) blur to an image.
 
     Parameters
@@ -63,7 +53,7 @@ def box_blur(img: Image.Image, dim: int) -> Image.Image:
     PIL.Image.Image
         Blurred image with the same dimensions as the input.
     """
-    return _box_blur_impl(img, dim)
+    return _box_blur_impl(img, dim, get_backend(backend))
 
 
 

--- a/src/pyblur/box_blur.py
+++ b/src/pyblur/box_blur.py
@@ -1,8 +1,8 @@
 import numpy as np
-from numpy.typing import NDArray
 from PIL import Image
 from scipy.signal import convolve2d
 
+from pyblur._kernels import box_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
     _SUPPORTED_MODES,
@@ -14,7 +14,7 @@ from pyblur._validation import (
 
 def _box_blur_impl(img: Image.Image, dim: int) -> Image.Image:
     imgarray = np.array(img, dtype="float32")
-    kernel = _box_kernel(dim)
+    kernel = box_kernel(dim)
     if imgarray.ndim == 3:
         convolved = np.stack(
             [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
@@ -66,7 +66,4 @@ def box_blur(img: Image.Image, dim: int) -> Image.Image:
     return _box_blur_impl(img, dim)
 
 
-def _box_kernel(dim: int) -> NDArray[np.float32]:
-    kernel = np.ones((dim, dim), dtype=np.float32)
-    kernel /= np.count_nonzero(kernel)
-    return kernel
+

--- a/src/pyblur/defocus_blur.py
+++ b/src/pyblur/defocus_blur.py
@@ -1,7 +1,7 @@
 import numpy as np
 from PIL import Image
-from scipy.signal import convolve2d
 
+from pyblur._backends import Backend, get_backend
 from pyblur._kernels import disk_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
@@ -12,23 +12,13 @@ from pyblur._validation import (
 )
 
 
-def _defocus_blur_impl(img: Image.Image, dim: int) -> Image.Image:
-    imgarray = np.array(img, dtype="float32")
-    kernel = disk_kernel(dim)
-    if imgarray.ndim == 3:
-        convolved = np.stack(
-            [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
-             for c in range(imgarray.shape[2])],
-            axis=2,
-        )
-    else:
-        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
-    return Image.fromarray(convolved)
+def _defocus_blur_impl(img: Image.Image, dim: int, backend: Backend) -> Image.Image:
+    return backend.apply_kernel(img, disk_kernel(dim))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
-def defocus_blur_random(img: Image.Image) -> Image.Image:
+def defocus_blur_random(img: Image.Image, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a defocus blur with a randomly chosen kernel size.
 
     Parameters
@@ -42,13 +32,15 @@ def defocus_blur_random(img: Image.Image) -> Image.Image:
         Blurred image with the same dimensions as the input.
     """
     kerneldim = _KERNEL_DIMS[np.random.randint(0, len(_KERNEL_DIMS))]
-    return _defocus_blur_impl(img, kerneldim)
+    return _defocus_blur_impl(img, kerneldim, get_backend(backend))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
 @validate_dim(_KERNEL_DIMS)
-def defocus_blur(img: Image.Image, dim: int) -> Image.Image:
+def defocus_blur(
+    img: Image.Image, dim: int, *, backend: str | Backend | None = None
+) -> Image.Image:
     """Apply a defocus (disk) blur to an image.
 
     Parameters
@@ -63,7 +55,7 @@ def defocus_blur(img: Image.Image, dim: int) -> Image.Image:
     PIL.Image.Image
         Blurred image with the same dimensions as the input.
     """
-    return _defocus_blur_impl(img, dim)
+    return _defocus_blur_impl(img, dim, get_backend(backend))
 
 
 

--- a/src/pyblur/defocus_blur.py
+++ b/src/pyblur/defocus_blur.py
@@ -1,9 +1,8 @@
 import numpy as np
-from numpy.typing import NDArray
 from PIL import Image
 from scipy.signal import convolve2d
-from skimage.draw import disk
 
+from pyblur._kernels import disk_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
     _SUPPORTED_MODES,
@@ -15,7 +14,7 @@ from pyblur._validation import (
 
 def _defocus_blur_impl(img: Image.Image, dim: int) -> Image.Image:
     imgarray = np.array(img, dtype="float32")
-    kernel = _disk_kernel(dim)
+    kernel = disk_kernel(dim)
     if imgarray.ndim == 3:
         convolved = np.stack(
             [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
@@ -67,20 +66,4 @@ def defocus_blur(img: Image.Image, dim: int) -> Image.Image:
     return _defocus_blur_impl(img, dim)
 
 
-def _disk_kernel(dim: int) -> NDArray[np.float32]:
-    kernel = np.zeros((dim, dim), dtype=np.float32)
-    center = dim // 2
-    rr, cc = disk((center, center), center + 1, shape=kernel.shape)
-    kernel[rr, cc] = 1
-    if dim == 3 or dim == 5:
-        kernel = _adjust(kernel, dim)
-    kernel /= np.count_nonzero(kernel)
-    return kernel
 
-
-def _adjust(kernel: NDArray[np.float32], kernelwidth: int) -> NDArray[np.float32]:
-    kernel[0, 0] = 0
-    kernel[0, kernelwidth - 1] = 0
-    kernel[kernelwidth - 1, 0] = 0
-    kernel[kernelwidth - 1, kernelwidth - 1] = 0
-    return kernel

--- a/src/pyblur/gaussian_blur.py
+++ b/src/pyblur/gaussian_blur.py
@@ -1,17 +1,18 @@
 import numpy as np
-from PIL import Image, ImageFilter
+from PIL import Image
 
+from pyblur._backends import Backend, get_backend
 from pyblur._validation import validate_image
 
 _GAUSSIAN_BANDWIDTHS = [0.5, 1, 1.5, 2, 2.5, 3, 3.5]
 
 
-def _gaussian_blur_impl(img: Image.Image, bandwidth: float) -> Image.Image:
-    return img.filter(ImageFilter.GaussianBlur(bandwidth))
+def _gaussian_blur_impl(img: Image.Image, bandwidth: float, backend: Backend) -> Image.Image:
+    return backend.gaussian_blur(img, bandwidth)
 
 
 @validate_image
-def gaussian_blur_random(img: Image.Image) -> Image.Image:
+def gaussian_blur_random(img: Image.Image, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a Gaussian blur with a randomly chosen bandwidth.
 
     Parameters
@@ -26,11 +27,13 @@ def gaussian_blur_random(img: Image.Image) -> Image.Image:
         Blurred image with the same dimensions as the input.
     """
     bandwidth = _GAUSSIAN_BANDWIDTHS[np.random.randint(0, len(_GAUSSIAN_BANDWIDTHS))]
-    return _gaussian_blur_impl(img, bandwidth)
+    return _gaussian_blur_impl(img, bandwidth, get_backend(backend))
 
 
 @validate_image
-def gaussian_blur(img: Image.Image, bandwidth: float) -> Image.Image:
+def gaussian_blur(
+    img: Image.Image, bandwidth: float, *, backend: str | Backend | None = None
+) -> Image.Image:
     """Apply a Gaussian blur to an image.
 
     Parameters
@@ -48,4 +51,4 @@ def gaussian_blur(img: Image.Image, bandwidth: float) -> Image.Image:
     """
     if not isinstance(bandwidth, (int, float)) or bandwidth <= 0:
         raise ValueError(f"gaussian_blur() bandwidth must be a positive number, got {bandwidth!r}")
-    return _gaussian_blur_impl(img, bandwidth)
+    return _gaussian_blur_impl(img, bandwidth, get_backend(backend))

--- a/src/pyblur/linear_motion_blur.py
+++ b/src/pyblur/linear_motion_blur.py
@@ -1,12 +1,10 @@
-import math
 from typing import Literal
 
 import numpy as np
-from numpy.typing import NDArray
 from PIL import Image
 from scipy.signal import convolve2d
-from skimage.draw import line
 
+from pyblur._kernels import line_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
     _SUPPORTED_MODES,
@@ -25,7 +23,7 @@ def _linear_motion_blur_impl(
     linetype: Literal["full", "right", "left"],
 ) -> Image.Image:
     imgarray = np.array(img, dtype="float32")
-    kernel = _line_kernel(dim, angle, linetype)
+    kernel = line_kernel(dim, angle, linetype)
     if imgarray.ndim == 3:
         convolved = np.stack(
             [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
@@ -91,41 +89,7 @@ def linear_motion_blur(
     return _linear_motion_blur_impl(img, dim, angle, linetype)
 
 
-def _line_endpoints(dim: int, angle: float) -> tuple[int, int, int, int]:
-    """Compute boundary-crossing line endpoints for a *dim*×*dim* kernel at *angle* degrees.
 
-    Angles outside ``[0°, 180°)`` are wrapped modulo 180°.  Returns
-    ``(r0, c0, r1, c1)`` clamped to ``[0, dim-1]``.
-    """
-    c = dim // 2
-    rad = math.radians(math.fmod(angle, 180.0))
-    dr = -math.sin(rad)  # row delta (row 0 is top, so sin is negated)
-    dc = math.cos(rad)   # col delta
-    t_row = c / abs(dr) if abs(dr) > 1e-9 else float("inf")
-    t_col = c / abs(dc) if abs(dc) > 1e-9 else float("inf")
-    t = min(t_row, t_col)
-    edge = dim - 1
-    r0 = max(0, min(edge, int(round(c - t * dr))))
-    c0 = max(0, min(edge, int(round(c - t * dc))))
-    r1 = max(0, min(edge, int(round(c + t * dr))))
-    c1 = max(0, min(edge, int(round(c + t * dc))))
-    return r0, c0, r1, c1
-
-
-def _line_kernel(
-    dim: int, angle: float, linetype: Literal["full", "right", "left"]
-) -> NDArray[np.float32]:
-    kernel_center = dim // 2
-    r0, c0, r1, c1 = _line_endpoints(dim, angle)
-    if linetype == "right":
-        r0, c0 = kernel_center, kernel_center
-    elif linetype == "left":
-        r1, c1 = kernel_center, kernel_center
-    rr, cc = line(r0, c0, r1, c1)
-    kernel = np.zeros((dim, dim), dtype=np.float32)
-    kernel[rr, cc] = 1
-    kernel /= np.count_nonzero(kernel)
-    return kernel
 
 
 def _random_angle() -> float:

--- a/src/pyblur/linear_motion_blur.py
+++ b/src/pyblur/linear_motion_blur.py
@@ -2,8 +2,8 @@ from typing import Literal
 
 import numpy as np
 from PIL import Image
-from scipy.signal import convolve2d
 
+from pyblur._backends import Backend, get_backend
 from pyblur._kernels import line_kernel
 from pyblur._validation import (
     _KERNEL_DIMS,
@@ -21,23 +21,16 @@ def _linear_motion_blur_impl(
     dim: int,
     angle: float,
     linetype: Literal["full", "right", "left"],
+    backend: Backend,
 ) -> Image.Image:
-    imgarray = np.array(img, dtype="float32")
-    kernel = line_kernel(dim, angle, linetype)
-    if imgarray.ndim == 3:
-        convolved = np.stack(
-            [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
-             for c in range(imgarray.shape[2])],
-            axis=2,
-        )
-    else:
-        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
-    return Image.fromarray(convolved)
+    return backend.apply_kernel(img, line_kernel(dim, angle, linetype))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
-def linear_motion_blur_random(img: Image.Image) -> Image.Image:
+def linear_motion_blur_random(
+    img: Image.Image, *, backend: str | Backend | None = None
+) -> Image.Image:
     """Apply a linear motion blur with randomly chosen parameters.
 
     Parameters
@@ -53,14 +46,19 @@ def linear_motion_blur_random(img: Image.Image) -> Image.Image:
     line_length = _KERNEL_DIMS[np.random.randint(0, len(_KERNEL_DIMS))]
     line_type = _LINE_TYPES[np.random.randint(0, len(_LINE_TYPES))]
     angle = _random_angle()
-    return _linear_motion_blur_impl(img, line_length, angle, line_type)
+    return _linear_motion_blur_impl(img, line_length, angle, line_type, get_backend(backend))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
 @validate_odd_dim
 def linear_motion_blur(
-    img: Image.Image, dim: int, angle: float, linetype: Literal["full", "right", "left"]
+    img: Image.Image,
+    dim: int,
+    angle: float,
+    linetype: Literal["full", "right", "left"],
+    *,
+    backend: str | Backend | None = None,
 ) -> Image.Image:
     """Apply a linear motion blur to an image.
 
@@ -86,7 +84,7 @@ def linear_motion_blur(
         raise ValueError(
             f"linear_motion_blur() linetype must be one of {_LINE_TYPES}, got {linetype!r}"
         )
-    return _linear_motion_blur_impl(img, dim, angle, linetype)
+    return _linear_motion_blur_impl(img, dim, angle, linetype, get_backend(backend))
 
 
 

--- a/src/pyblur/psf_blur.py
+++ b/src/pyblur/psf_blur.py
@@ -1,26 +1,15 @@
-import os.path
-
 import numpy as np
-from numpy.lib.npyio import NpzFile
 from PIL import Image
 from scipy.signal import convolve2d
 
+from pyblur._kernels import psf_kernel
 from pyblur._validation import _SUPPORTED_MODES, validate_image, validate_mode
 
 _PSF_COUNT = 100
-_psf_data: NpzFile | None = None
-
-
-def _load_psf() -> NpzFile:
-    global _psf_data
-    if _psf_data is None:
-        npz_path = os.path.join(os.path.dirname(__file__), "psf.npz")
-        _psf_data = np.load(npz_path, allow_pickle=False)
-    return _psf_data
 
 
 def _psf_blur_impl(img: Image.Image, psfid: int) -> Image.Image:
-    kernel = _load_psf()[str(psfid)]
+    kernel = psf_kernel(psfid)
     imgarray = np.array(img, dtype="float32")
     if imgarray.ndim == 3:
         convolved = np.stack(
@@ -72,7 +61,6 @@ def psf_blur_random(img: Image.Image) -> Image.Image:
     PIL.Image.Image
         Blurred image with the same dimensions as the input.
     """
-    psf = _load_psf()
-    psfid = np.random.randint(0, len(psf))
+    psfid = np.random.randint(0, _PSF_COUNT)
     return _psf_blur_impl(img, psfid)
 

--- a/src/pyblur/psf_blur.py
+++ b/src/pyblur/psf_blur.py
@@ -1,30 +1,20 @@
 import numpy as np
 from PIL import Image
-from scipy.signal import convolve2d
 
+from pyblur._backends import Backend, get_backend
 from pyblur._kernels import psf_kernel
 from pyblur._validation import _SUPPORTED_MODES, validate_image, validate_mode
 
 _PSF_COUNT = 100
 
 
-def _psf_blur_impl(img: Image.Image, psfid: int) -> Image.Image:
-    kernel = psf_kernel(psfid)
-    imgarray = np.array(img, dtype="float32")
-    if imgarray.ndim == 3:
-        convolved = np.stack(
-            [convolve2d(imgarray[..., c], kernel, mode='same', fillvalue=255.0).astype("uint8")
-             for c in range(imgarray.shape[2])],
-            axis=2,
-        )
-    else:
-        convolved = convolve2d(imgarray, kernel, mode='same', fillvalue=255.0).astype("uint8")
-    return Image.fromarray(convolved)
+def _psf_blur_impl(img: Image.Image, psfid: int, backend: Backend) -> Image.Image:
+    return backend.apply_kernel(img, psf_kernel(psfid))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
-def psf_blur(img: Image.Image, psfid: int) -> Image.Image:
+def psf_blur(img: Image.Image, psfid: int, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a point-spread-function blur to an image.
 
     Parameters
@@ -43,12 +33,12 @@ def psf_blur(img: Image.Image, psfid: int) -> Image.Image:
         raise ValueError(
             f"psf_blur() psfid must be an integer in [0, {_PSF_COUNT - 1}], got {psfid!r}"
         )
-    return _psf_blur_impl(img, psfid)
+    return _psf_blur_impl(img, psfid, get_backend(backend))
 
 
 @validate_image
 @validate_mode(_SUPPORTED_MODES)
-def psf_blur_random(img: Image.Image) -> Image.Image:
+def psf_blur_random(img: Image.Image, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a point-spread-function blur with a randomly chosen kernel.
 
     Parameters
@@ -62,5 +52,5 @@ def psf_blur_random(img: Image.Image) -> Image.Image:
         Blurred image with the same dimensions as the input.
     """
     psfid = np.random.randint(0, _PSF_COUNT)
-    return _psf_blur_impl(img, psfid)
+    return _psf_blur_impl(img, psfid, get_backend(backend))
 

--- a/src/pyblur/randomized_blur.py
+++ b/src/pyblur/randomized_blur.py
@@ -1,6 +1,9 @@
+from typing import Callable
+
 import numpy as np
 from PIL import Image
 
+from pyblur._backends import Backend
 from pyblur._validation import validate_image
 from pyblur.box_blur import box_blur_random
 from pyblur.defocus_blur import defocus_blur_random
@@ -8,7 +11,7 @@ from pyblur.gaussian_blur import gaussian_blur_random
 from pyblur.linear_motion_blur import linear_motion_blur_random
 from pyblur.psf_blur import psf_blur_random
 
-_BLUR_FUNCTIONS = [
+_BLUR_FUNCTIONS: list[Callable[..., Image.Image]] = [
     box_blur_random,
     defocus_blur_random,
     gaussian_blur_random,
@@ -18,7 +21,7 @@ _BLUR_FUNCTIONS = [
 
 
 @validate_image
-def randomized_blur(img: Image.Image) -> Image.Image:
+def randomized_blur(img: Image.Image, *, backend: str | Backend | None = None) -> Image.Image:
     """Apply a randomly chosen blur to an image.
 
     One of box, defocus, Gaussian, linear motion, or PSF blur is selected
@@ -34,4 +37,4 @@ def randomized_blur(img: Image.Image) -> Image.Image:
     PIL.Image.Image
         Blurred image with the same dimensions as the input.
     """
-    return _BLUR_FUNCTIONS[np.random.randint(0, len(_BLUR_FUNCTIONS))](img)
+    return _BLUR_FUNCTIONS[np.random.randint(0, len(_BLUR_FUNCTIONS))](img, backend=backend)

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -1,0 +1,384 @@
+"""Tests for the backend registry and PilScipyBackend."""
+import sys
+
+import numpy as np
+import pytest
+from PIL import Image
+
+import pyblur
+from pyblur._backends import Backend, get_backend, set_default
+from pyblur._backends._numpy import PilNumpyBackend
+from pyblur._backends._opencv import PilOpenCVBackend
+from pyblur._backends._pil_scipy import PilScipyBackend
+
+# ---------------------------------------------------------------------------
+# Registry behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_get_default_is_scipy(self) -> None:
+        b = get_backend(None)
+        assert b.name == "scipy"
+
+    def test_get_by_name(self) -> None:
+        b = get_backend("scipy")
+        assert b.name == "scipy"
+
+    def test_numpy_always_registered(self) -> None:
+        b = get_backend("numpy")
+        assert b.name == "numpy"
+
+    def test_opencv_registered(self) -> None:
+        b = get_backend("opencv")
+        assert b.name == "opencv"
+
+    def test_get_unknown_name_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown backend"):
+            get_backend("nonexistent")
+
+    def test_set_default_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown backend"):
+            set_default("totally_unknown_xyz")
+
+    def test_get_backend_instance_passthrough(self) -> None:
+        b = PilScipyBackend()
+        result = get_backend(b)
+        assert result is b
+
+    def test_pil_scipy_satisfies_protocol(self) -> None:
+        b = PilScipyBackend()
+        assert isinstance(b, Backend)
+
+    def test_pil_numpy_satisfies_protocol(self) -> None:
+        b = PilNumpyBackend()
+        assert isinstance(b, Backend)
+
+    def test_pil_opencv_satisfies_protocol(self) -> None:
+        b = PilOpenCVBackend()
+        assert isinstance(b, Backend)
+
+    def test_fallback_to_numpy_when_scipy_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When _pil_scipy cannot be imported, default falls back to numpy."""
+        import pyblur._backends as bmod
+
+        saved_registry = dict(bmod._registry)
+        saved_default = bmod._default
+        monkeypatch.setitem(sys.modules, "pyblur._backends._pil_scipy", None)
+        bmod._registry.clear()
+        bmod._default = None
+        try:
+            bmod._init_backends()
+            assert bmod._default is not None
+            assert bmod._default.name == "numpy"
+            assert "numpy" in bmod._registry
+            assert "scipy" not in bmod._registry
+        finally:
+            bmod._registry.clear()
+            bmod._registry.update(saved_registry)
+            bmod._default = saved_default
+
+    def test_fallback_when_opencv_unavailable(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When _opencv cannot be imported, opencv backend is simply absent."""
+        import pyblur._backends as bmod
+
+        saved_registry = dict(bmod._registry)
+        saved_default = bmod._default
+        monkeypatch.setitem(sys.modules, "pyblur._backends._opencv", None)
+        bmod._registry.clear()
+        bmod._default = None
+        try:
+            bmod._init_backends()
+            assert "opencv" not in bmod._registry
+            assert bmod._default is not None
+            assert bmod._default.name == "scipy"
+        finally:
+            bmod._registry.clear()
+            bmod._registry.update(saved_registry)
+            bmod._default = saved_default
+
+
+# ---------------------------------------------------------------------------
+# PilScipyBackend unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPilScipyBackend:
+    @pytest.fixture()
+    def backend(self) -> PilScipyBackend:
+        return PilScipyBackend()
+
+    @pytest.fixture()
+    def gray(self) -> Image.Image:
+        return Image.new("L", (16, 16), color=128)
+
+    @pytest.fixture()
+    def rgb(self) -> Image.Image:
+        return Image.new("RGB", (16, 16), color=(100, 150, 200))
+
+    @pytest.fixture()
+    def kernel(self) -> np.ndarray:
+        return np.ones((3, 3), dtype=np.float32) / 9.0
+
+    def test_apply_kernel_grayscale(
+        self, backend: PilScipyBackend, gray: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(gray, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "L"
+        assert out.size == gray.size
+
+    def test_apply_kernel_rgb(
+        self, backend: PilScipyBackend, rgb: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(rgb, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "RGB"
+        assert out.size == rgb.size
+
+    def test_gaussian_blur(
+        self, backend: PilScipyBackend, gray: Image.Image
+    ) -> None:
+        out = backend.gaussian_blur(gray, sigma=1.5)
+        assert isinstance(out, Image.Image)
+        assert out.size == gray.size
+
+
+# ---------------------------------------------------------------------------
+# Integration: backend= kwarg accepted by every public function
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def gray() -> Image.Image:
+    return Image.new("L", (16, 16), color=128)
+
+
+@pytest.mark.parametrize(
+    "fn,extra_args",
+    [
+        (pyblur.box_blur, (3,)),
+        (pyblur.defocus_blur, (3,)),
+        (pyblur.gaussian_blur, (1.5,)),
+        (pyblur.linear_motion_blur, (5, 45.0, "full")),
+        (pyblur.psf_blur, (0,)),
+    ],
+)
+def test_explicit_backend_string(
+    gray: Image.Image, fn: object, extra_args: tuple[object, ...]
+) -> None:
+    """Passing backend='scipy' explicitly must return a valid PIL image."""
+    assert callable(fn)
+    result = fn(gray, *extra_args, backend="scipy")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pyblur.box_blur_random,
+        pyblur.defocus_blur_random,
+        pyblur.gaussian_blur_random,
+        pyblur.linear_motion_blur_random,
+        pyblur.psf_blur_random,
+        pyblur.randomized_blur,
+    ],
+)
+def test_explicit_backend_string_random(
+    gray: Image.Image, fn: object
+) -> None:
+    """Random variants also accept backend= and return a valid PIL image."""
+    assert callable(fn)
+    result = fn(gray, backend="scipy")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)
+
+
+def test_backend_instance_passthrough(gray: Image.Image) -> None:
+    """A Backend instance may be passed directly instead of a string name."""
+    b = PilScipyBackend()
+    result = pyblur.box_blur(gray, 3, backend=b)
+    assert isinstance(result, Image.Image)
+
+
+# ---------------------------------------------------------------------------
+# PilNumpyBackend unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestPilNumpyBackend:
+    @pytest.fixture()
+    def backend(self) -> PilNumpyBackend:
+        return PilNumpyBackend()
+
+    @pytest.fixture()
+    def gray(self) -> Image.Image:
+        return Image.new("L", (16, 16), color=128)
+
+    @pytest.fixture()
+    def rgb(self) -> Image.Image:
+        return Image.new("RGB", (16, 16), color=(100, 150, 200))
+
+    @pytest.fixture()
+    def kernel(self) -> np.ndarray:
+        return np.ones((3, 3), dtype=np.float32) / 9.0
+
+    def test_apply_kernel_grayscale(
+        self, backend: PilNumpyBackend, gray: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(gray, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "L"
+        assert out.size == gray.size
+
+    def test_apply_kernel_rgb(
+        self, backend: PilNumpyBackend, rgb: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(rgb, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "RGB"
+        assert out.size == rgb.size
+
+    def test_gaussian_blur(
+        self, backend: PilNumpyBackend, gray: Image.Image
+    ) -> None:
+        out = backend.gaussian_blur(gray, sigma=1.5)
+        assert isinstance(out, Image.Image)
+        assert out.size == gray.size
+
+
+# ---------------------------------------------------------------------------
+# Integration: numpy backend accepted by every public function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn,extra_args",
+    [
+        (pyblur.box_blur, (3,)),
+        (pyblur.defocus_blur, (3,)),
+        (pyblur.gaussian_blur, (1.5,)),
+        (pyblur.linear_motion_blur, (5, 45.0, "full")),
+        (pyblur.psf_blur, (0,)),
+    ],
+)
+def test_numpy_backend_explicit(
+    gray: Image.Image, fn: object, extra_args: tuple[object, ...]
+) -> None:
+    """backend='numpy' must return a valid PIL image for every deterministic function."""
+    assert callable(fn)
+    result = fn(gray, *extra_args, backend="numpy")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pyblur.box_blur_random,
+        pyblur.defocus_blur_random,
+        pyblur.gaussian_blur_random,
+        pyblur.linear_motion_blur_random,
+        pyblur.psf_blur_random,
+        pyblur.randomized_blur,
+    ],
+)
+def test_numpy_backend_explicit_random(
+    gray: Image.Image, fn: object
+) -> None:
+    """backend='numpy' must return a valid PIL image for every random function."""
+    assert callable(fn)
+    result = fn(gray, backend="numpy")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: PilOpenCVBackend
+# ---------------------------------------------------------------------------
+
+
+class TestPilOpenCVBackend:
+    @pytest.fixture()
+    def backend(self) -> PilOpenCVBackend:
+        return PilOpenCVBackend()
+
+    @pytest.fixture()
+    def gray(self) -> Image.Image:
+        return Image.new("L", (16, 16), color=128)
+
+    @pytest.fixture()
+    def rgb(self) -> Image.Image:
+        return Image.new("RGB", (16, 16), color=(100, 150, 200))
+
+    @pytest.fixture()
+    def kernel(self) -> np.ndarray:
+        return np.ones((3, 3), dtype=np.float32) / 9.0
+
+    def test_apply_kernel_grayscale(
+        self, backend: PilOpenCVBackend, gray: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(gray, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "L"
+        assert out.size == gray.size
+
+    def test_apply_kernel_rgb(
+        self, backend: PilOpenCVBackend, rgb: Image.Image, kernel: np.ndarray
+    ) -> None:
+        out = backend.apply_kernel(rgb, kernel)
+        assert isinstance(out, Image.Image)
+        assert out.mode == "RGB"
+        assert out.size == rgb.size
+
+    def test_gaussian_blur(
+        self, backend: PilOpenCVBackend, gray: Image.Image
+    ) -> None:
+        out = backend.gaussian_blur(gray, sigma=1.5)
+        assert isinstance(out, Image.Image)
+        assert out.size == gray.size
+
+
+# ---------------------------------------------------------------------------
+# Integration: opencv backend accepted by every public function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fn,extra_args",
+    [
+        (pyblur.box_blur, (3,)),
+        (pyblur.defocus_blur, (3,)),
+        (pyblur.gaussian_blur, (1.5,)),
+        (pyblur.linear_motion_blur, (5, 45.0, "full")),
+        (pyblur.psf_blur, (0,)),
+    ],
+)
+def test_opencv_backend_explicit(
+    gray: Image.Image, fn: object, extra_args: tuple[object, ...]
+) -> None:
+    """backend='opencv' must return a valid PIL image for every deterministic function."""
+    assert callable(fn)
+    result = fn(gray, *extra_args, backend="opencv")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)
+
+
+@pytest.mark.parametrize(
+    "fn",
+    [
+        pyblur.box_blur_random,
+        pyblur.defocus_blur_random,
+        pyblur.gaussian_blur_random,
+        pyblur.linear_motion_blur_random,
+        pyblur.psf_blur_random,
+        pyblur.randomized_blur,
+    ],
+)
+def test_opencv_backend_explicit_random(
+    gray: Image.Image, fn: object
+) -> None:
+    """backend='opencv' must return a valid PIL image for every random function."""
+    assert callable(fn)
+    result = fn(gray, backend="opencv")  # type: ignore[operator]
+    assert isinstance(result, Image.Image)

--- a/tests/test_box_blur.py
+++ b/tests/test_box_blur.py
@@ -5,24 +5,24 @@ from conftest import assert_same_size
 from PIL import Image
 
 import pyblur
+from pyblur._kernels import box_kernel
 from pyblur._validation import _KERNEL_DIMS
-from pyblur.box_blur import _box_kernel
 
 
 class TestBoxKernel:
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_shape(self, dim: int) -> None:
-        k = _box_kernel(dim)
+        k = box_kernel(dim)
         assert k.shape == (dim, dim)
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_sums_to_one(self, dim: int) -> None:
-        k = _box_kernel(dim)
+        k = box_kernel(dim)
         assert pytest.approx(k.sum(), abs=1e-6) == 1.0
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_uniform(self, dim: int) -> None:
-        k = _box_kernel(dim)
+        k = box_kernel(dim)
         expected = 1.0 / (dim * dim)
         assert np.allclose(k, expected)
 

--- a/tests/test_defocus_blur.py
+++ b/tests/test_defocus_blur.py
@@ -5,24 +5,24 @@ from conftest import assert_same_size
 from PIL import Image
 
 import pyblur
+from pyblur._kernels import disk_kernel
 from pyblur._validation import _KERNEL_DIMS
-from pyblur.defocus_blur import _disk_kernel
 
 
 class TestDiskKernel:
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_shape(self, dim: int) -> None:
-        k = _disk_kernel(dim)
+        k = disk_kernel(dim)
         assert k.shape == (dim, dim)
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_sums_to_one(self, dim: int) -> None:
-        k = _disk_kernel(dim)
+        k = disk_kernel(dim)
         assert pytest.approx(k.sum(), abs=1e-6) == 1.0
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     def test_non_negative(self, dim: int) -> None:
-        k = _disk_kernel(dim)
+        k = disk_kernel(dim)
         assert (k >= 0).all()
 
 

--- a/tests/test_linear_motion_blur.py
+++ b/tests/test_linear_motion_blur.py
@@ -7,8 +7,8 @@ from conftest import assert_same_size
 from PIL import Image
 
 import pyblur
+from pyblur._kernels import line_endpoints, line_kernel
 from pyblur._validation import _KERNEL_DIMS
-from pyblur.linear_motion_blur import _line_endpoints, _line_kernel
 
 _LINE_TYPES = ["full", "right", "left"]
 
@@ -17,19 +17,19 @@ class TestLineKernel:
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     @pytest.mark.parametrize("linetype", _LINE_TYPES)
     def test_shape(self, dim: int, linetype: str) -> None:
-        k = _line_kernel(dim, 0.0, linetype)  # type: ignore[arg-type]
+        k = line_kernel(dim, 0.0, linetype)  # type: ignore[arg-type]
         assert k.shape == (dim, dim)
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     @pytest.mark.parametrize("linetype", _LINE_TYPES)
     def test_sums_to_one(self, dim: int, linetype: str) -> None:
-        k = _line_kernel(dim, 45.0, linetype)  # type: ignore[arg-type]
+        k = line_kernel(dim, 45.0, linetype)  # type: ignore[arg-type]
         assert pytest.approx(k.sum(), abs=1e-6) == 1.0
 
     @pytest.mark.parametrize("dim", _KERNEL_DIMS)
     @pytest.mark.parametrize("linetype", _LINE_TYPES)
     def test_non_negative(self, dim: int, linetype: str) -> None:
-        k = _line_kernel(dim, 90.0, linetype)  # type: ignore[arg-type]
+        k = line_kernel(dim, 90.0, linetype)  # type: ignore[arg-type]
         assert (k >= 0).all()
 
 
@@ -147,16 +147,16 @@ class TestLineEndpoints:
     def test_canonical_values(
         self, dim: int, angle: float, expected: tuple[int, int, int, int]
     ) -> None:
-        result = _line_endpoints(dim, angle)
+        result = line_endpoints(dim, angle)
         rev = (expected[2], expected[3], expected[0], expected[1])
         assert result == expected or result == rev, (
-            f"_line_endpoints({dim}, {angle}) = {result}, expected {expected} or {rev}"
+            f"line_endpoints({dim}, {angle}) = {result}, expected {expected} or {rev}"
         )
 
     @pytest.mark.parametrize("dim", [3, 5, 7, 9, 11, 13])
     @pytest.mark.parametrize("angle", [0.0, 22.5, 45.0, 90.0, 135.0, 157.5, 177.3])
     def test_endpoints_within_bounds(self, dim: int, angle: float) -> None:
-        r0, c0, r1, c1 = _line_endpoints(dim, angle)
+        r0, c0, r1, c1 = line_endpoints(dim, angle)
         assert 0 <= r0 < dim and 0 <= c0 < dim
         assert 0 <= r1 < dim and 0 <= c1 < dim
 
@@ -164,16 +164,16 @@ class TestLineEndpoints:
     @pytest.mark.parametrize("angle", [0.0, 45.0, 90.0, 135.0])
     def test_endpoints_symmetric_around_center(self, dim: int, angle: float) -> None:
         c = dim // 2
-        r0, c0, r1, c1 = _line_endpoints(dim, angle)
+        r0, c0, r1, c1 = line_endpoints(dim, angle)
         assert (r0 + r1) // 2 == c or abs((r0 + r1) / 2 - c) < 1.0
         assert (c0 + c1) // 2 == c or abs((c0 + c1) / 2 - c) < 1.0
 
     def test_angle_wrap_360(self) -> None:
-        assert _line_endpoints(9, 0.0) == _line_endpoints(9, 180.0)
+        assert line_endpoints(9, 0.0) == line_endpoints(9, 180.0)
 
     def test_large_dim_shape(self) -> None:
         for dim in [11, 13, 15]:
-            r0, c0, r1, c1 = _line_endpoints(dim, 45.0)
+            r0, c0, r1, c1 = line_endpoints(dim, 45.0)
             assert r0 == dim - 1 and c0 == 0 and r1 == 0 and c1 == dim - 1
 
 
@@ -181,17 +181,17 @@ class TestLineKernelParity:
     """Verify dynamic computation produces the geometrically correct kernel."""
 
     def test_horizontal_kernel(self) -> None:
-        k = _line_kernel(5, 0.0, "full")
+        k = line_kernel(5, 0.0, "full")
         assert np.allclose(k[2], np.full(5, 0.2))
         assert k[:2].sum() == 0 and k[3:].sum() == 0
 
     def test_vertical_kernel(self) -> None:
-        k = _line_kernel(5, 90.0, "full")
+        k = line_kernel(5, 90.0, "full")
         assert np.allclose(k[:, 2], np.full(5, 0.2))
         assert k[:, :2].sum() == 0 and k[:, 3:].sum() == 0
 
     @pytest.mark.parametrize("dim", [11, 13, 15])
     def test_large_dim_sums_to_one(self, dim: int) -> None:
         for angle in [0.0, 45.0, 90.0, 135.0]:
-            k = _line_kernel(dim, angle, "full")
+            k = line_kernel(dim, angle, "full")
             assert pytest.approx(k.sum(), abs=1e-5) == 1.0

--- a/uv.lock
+++ b/uv.lock
@@ -352,6 +352,25 @@ wheels = [
 ]
 
 [[package]]
+name = "opencv-python"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ac/6c98c44c650b8114a0fb901691351cfb3956d502e8e9b5cd27f4ee7fbf2f/opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9", size = 32568781, upload-time = "2026-02-05T07:01:41.379Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/51/82fed528b45173bf629fa44effb76dff8bc9f4eeaee759038362dfa60237/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bc2596e68f972ca452d80f444bc404e08807d021fbba40df26b61b18e01838a", size = 47685527, upload-time = "2026-02-05T06:59:11.24Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bccaabf9eb7f897ca61880ce2869dcd9b25b72129c28478e7f2a5e8dee945616", size = 46708208, upload-time = "2026-02-05T06:59:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -475,6 +494,13 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pillow" },
+]
+
+[package.optional-dependencies]
+opencv = [
+    { name = "opencv-python" },
+]
+scipy = [
     { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -483,25 +509,35 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "opencv-python" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "scikit-image", version = "0.25.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scikit-image", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "ty" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "numpy", specifier = ">=1.21" },
+    { name = "opencv-python", marker = "extra == 'opencv'", specifier = ">=4.5" },
     { name = "pillow", specifier = ">=9.0" },
-    { name = "scikit-image", specifier = ">=0.20" },
-    { name = "scipy", specifier = ">=1.7" },
+    { name = "scikit-image", marker = "extra == 'scipy'", specifier = ">=0.20" },
+    { name = "scipy", marker = "extra == 'scipy'", specifier = ">=1.7" },
 ]
+provides-extras = ["scipy", "opencv"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "opencv-python", specifier = ">=4.5" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.15.6" },
+    { name = "scikit-image", specifier = ">=0.20" },
+    { name = "scipy", specifier = ">=1.7" },
     { name = "ty" },
 ]
 


### PR DESCRIPTION
## Summary

Introduces a pluggable convolution backend system. All public blur functions now accept an optional `backend=` keyword argument; the correct engine is selected automatically at import time with no breaking change for existing users.

## Changes

### New: pluggable backend architecture
- Added a `Backend` protocol (`_backends/`) with a shared registry and `get_backend()` / `set_default()` helpers.
- All public functions (`box_blur`, `defocus_blur`, `gaussian_blur`, `linear_motion_blur`, `psf_blur`, their `_random` variants, and `randomized_blur`) accept `backend: str | Backend | None = None`.

### New backends
| Backend | Trigger |
|---------|---------|
| `"scipy"` | registered and set as default when scipy is importable — identical output to v1.2 |
| `"numpy"` | always registered; becomes default when scipy is absent |
| `"opencv"` | registered when `opencv-python` is importable; opt-in only via `backend="opencv"` |

### Dependency changes
- `scipy` and `scikit-image` moved from hard dependencies to the `[scipy]` optional extra.
- `[opencv]` optional extra added (`opencv-python>=4.5`).
- Core install (`pip install pyblur`) now requires only `numpy` and `pillow`.

### Internal
- Kernel generation extracted into `_kernels.py`; `skimage.draw` replaced with pure-numpy equivalents (`np.ogrid` disk mask, inline Bresenham line), removing the scikit-image hard dependency entirely.

## Testing

490 tests, 100% branch coverage across all modules. All existing tests pass unchanged.

```
src/pyblur/_backends/__init__.py    100%
src/pyblur/_backends/_numpy.py      100%
src/pyblur/_backends/_opencv.py     100%
src/pyblur/_backends/_pil_scipy.py  100%
src/pyblur/_kernels.py              100%
```

## Migration

No action required for existing users — if scipy is installed, the default backend and all outputs are identical to v1.2.

To opt out of scipy:
```bash
pip install pyblur  # numpy backend used automatically
```

To use OpenCV:
```bash
pip install pyblur[opencv]
blurred = pyblur.box_blur(img, dim=5, backend="opencv")
```